### PR TITLE
Travis lint error proposed fix

### DIFF
--- a/neuroc_travis.yml
+++ b/neuroc_travis.yml
@@ -37,10 +37,10 @@ after_failure:
 before_deploy:
   - R CMD INSTALL --build ${PKG_TARBALL}
   # so no overwrite of linux build
-  - if [ "$TRAVIS_OS_NAME" == "osx" ];
+  - 'if [ "$TRAVIS_OS_NAME" == "osx" ];
     then
     rm -f *.tar.gz
-  fi
+  fi'
 
 deploy:
   provider: releases

--- a/neuroc_travis_ants.yml
+++ b/neuroc_travis_ants.yml
@@ -67,10 +67,10 @@ after_success:
 
 # so no overwrite of linux build
 before_deploy:
-  - if [ "$TRAVIS_OS_NAME" == "osx" ];
+  - 'if [ "$TRAVIS_OS_NAME" == "osx" ];
     then
     rm -f *.tar.gz
-  fi
+  fi'
 
 deploy:
   provider: releases


### PR DESCRIPTION
This seems to "calm" the lint checker for the .travis.yml file and the NeuroC backend is once again able to generate proper travis yml files (the error was showing up when using travis encrypt to generate on the spot the deploy API key based on the user defined GitHub personal access token).